### PR TITLE
Added bower.js to support Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,25 @@
+{
+  "name": "numbers2words",
+  "description": "Numbers to words converter.",
+  "main": "./build/numbers2words.min.js",
+  "authors": [
+    "Tomas Jurman <tomasjurman@gmail.com>"
+  ],
+  "license": "MIT",
+  "keywords": [
+    "number",
+    "word",
+    "converter"
+  ],
+  "homepage": "https://github.com/Kibo/numbers2words.git",
+  "moduleType": [
+    "globals"
+  ],
+  "ignore": [
+    "node_modules",
+    "src",
+    "test",
+    "gruntfile.json",
+    "package.json"
+  ]
+}


### PR DESCRIPTION
This PR is to support bower (see #5). It is very easy to integrate.

If you have merged this PR you just have to 
* create a version Git tag (according to [semver](http://semver.org/))
  `git tag v0.3.0`
* and register your package via
  `bower register numbers2words git://github.com/Kibo/numbers2words.git`

That's all :-)
Would be kind if you could do that.